### PR TITLE
Add logic for handling empty Face API response

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,8 +27,7 @@ app.set('environment', process.env.NODE_ENV);
 
 
 // view engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'jade');
+// app.set('views', path.join(__dirname, 'views'));
 
 app.use(logger('dev'));
 app.use(express.json());
@@ -52,9 +51,9 @@ app.use(function(err, req, res, next) {
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 
-  // render the error page
+  // send the error as JSON
   res.status(err.status || 500);
-  res.render('error');
+  res.json({ error: err });
 });
 
 module.exports = app;

--- a/routes/api.js
+++ b/routes/api.js
@@ -36,8 +36,24 @@ router.post('/upload', cors(), apiUpload, asyncHandler(async(req, res, next) => 
   await faceClient.face
     .detectWithStream(image, faceDetectFromStreamOptionalParams)
     .then(result => {
+      // If result is empty, aka no faces detected, then return 400
+      console.log(result);
+      if (result.length === 0) {
+        // res.status(400).send( "Couldn't detect a singular face! Make sure your face is alone and visible." );
+        // return;
+        const err = {
+          message: "Couldn't detect a singular face! Make sure your face is alone and visible.",
+          status: 400
+        };
+        return next(err);
+      }
       emotion = getHighestEmotion(result[0].faceAttributes.emotion);
     });
+
+  // If Face API didn't return a valid response, we need to stop execution
+  if (emotion === '') {
+    return;
+  }
 
   await spotifyAPI.clientCredentialsGrant().then(
     function(data) {      


### PR DESCRIPTION
Backend now returns a response for when the Azure Face API doesn't return a valid response (aka empty) for the frontend to display to the user.